### PR TITLE
Add LAMP stack deployment using CloudFormation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Deploying a LAMP Stack using AWS CloudFormation
+
+This guide provides instructions for deploying a LAMP (Linux, Apache, MySQL, PHP) stack using AWS CloudFormation. The stack will be created using a single EC2 instance and a local MySQL database for storage.
+
+## Prerequisites
+
+Before you begin, ensure you have the following:
+
+* An AWS account
+* AWS CLI installed and configured
+* A key pair for accessing the EC2 instance
+
+## Steps to Deploy the LAMP Stack
+
+1. **Create the CloudFormation Stack**
+
+   Use the provided CloudFormation template to create the LAMP stack. The template is located at `cloudformation/lamp-stack.yaml`.
+
+   ```bash
+   aws cloudformation create-stack --stack-name LampStack --template-body file://cloudformation/lamp-stack.yaml --parameters ParameterKey=KeyName,ParameterValue=<your-key-pair-name>
+   ```
+
+   Replace `<your-key-pair-name>` with the name of your key pair.
+
+2. **Wait for the Stack to be Created**
+
+   Monitor the stack creation process. You can use the AWS Management Console or the AWS CLI to check the status of the stack.
+
+   ```bash
+   aws cloudformation describe-stacks --stack-name LampStack
+   ```
+
+   Wait until the stack status is `CREATE_COMPLETE`.
+
+3. **Access the PHP Info Page**
+
+   Once the stack is created, you can access the PHP info page to verify the installation. The URL of the PHP info page is provided in the stack outputs.
+
+   ```bash
+   aws cloudformation describe-stacks --stack-name LampStack --query "Stacks[0].Outputs[?OutputKey=='WebsiteURL'].OutputValue" --output text
+   ```
+
+   Open the URL in a web browser to see the PHP info page.
+
+## CloudFormation Template
+
+The CloudFormation template `cloudformation/lamp-stack.yaml` defines the resources required for the LAMP stack, including an EC2 instance, security group, and IAM role. The user data script in the template installs Apache, PHP, and MySQL on the EC2 instance.
+
+## Shell Script for LAMP Installation
+
+The shell script `scripts/install-lamp.sh` is used to install Apache, PHP, and MySQL on the EC2 instance. The script performs the following actions:
+
+* Updates the package repository and installs necessary packages
+* Starts and enables Apache and MySQL services
+* Secures the MySQL installation
+* Creates a PHP info file to test the PHP installation
+
+You can find the script at `scripts/install-lamp.sh`.

--- a/cloudformation/lamp-stack.yaml
+++ b/cloudformation/lamp-stack.yaml
@@ -1,0 +1,73 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: "Create a LAMP stack using a single EC2 instance and a local MySQL database for storage. This template demonstrates using the AWS CloudFormation bootstrap scripts to install the packages and files necessary to deploy the Apache web server, PHP, and MySQL when the instance is launched."
+
+Resources:
+  LampInstance:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      InstanceType: t2.micro
+      SecurityGroups:
+        - !Ref LampSecurityGroup
+      KeyName: !Ref KeyName
+      ImageId: ami-0c55b159cbfafe1f0
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          yum update -y
+          yum install -y httpd mariadb-server php php-mysqlnd
+          systemctl start httpd
+          systemctl enable httpd
+          systemctl start mariadb
+          systemctl enable mariadb
+          mysql_secure_installation
+          echo "<?php phpinfo(); ?>" > /var/www/html/info.php
+
+  LampSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Enable HTTP and HTTPS access
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+
+  LampInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Roles:
+        - !Ref LampInstanceRole
+
+  LampInstanceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LampInstancePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:Describe*
+                  - s3:ListBucket
+                Resource: '*'
+
+Outputs:
+  InstancePublicIP:
+    Description: Public IP address of the newly created EC2 instance
+    Value: !GetAtt LampInstance.PublicIp
+
+  WebsiteURL:
+    Description: URL of the PHP info page
+    Value: !Sub 'http://${LampInstance.PublicIp}/info.php'

--- a/scripts/install-lamp.sh
+++ b/scripts/install-lamp.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Update package repository and install necessary packages
+sudo yum update -y
+sudo yum install -y httpd mariadb-server php php-mysqlnd
+
+# Start and enable Apache and MySQL services
+sudo systemctl start httpd
+sudo systemctl enable httpd
+sudo systemctl start mariadb
+sudo systemctl enable mariadb
+
+# Secure the MySQL installation
+sudo mysql_secure_installation
+
+# Create a PHP info file to test the PHP installation
+echo "<?php phpinfo(); ?>" | sudo tee /var/www/html/info.php


### PR DESCRIPTION
Add CloudFormation template and shell script to deploy a LAMP stack on AWS.

* **CloudFormation Template (`cloudformation/lamp-stack.yaml`)**
  - Create a CloudFormation template to define the LAMP stack.
  - Include resources for an EC2 instance, security group, and IAM role.
  - Add user data script to install Apache, PHP, and MySQL.
  - Configure security group to allow HTTP and HTTPS traffic.
  - Add outputs for the instance public IP and website URL.

* **Shell Script (`scripts/install-lamp.sh`)**
  - Create a shell script to install Apache, PHP, and MySQL.
  - Update package repository and install necessary packages.
  - Start and enable Apache and MySQL services.
  - Secure the MySQL installation.
  - Create a PHP info file to test the PHP installation.

* **Documentation (`README.md`)**
  - Add instructions for deploying the LAMP stack using CloudFormation.
  - Include steps to launch the CloudFormation stack.
  - Add a section on how to access the PHP info page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Nichebiche/git-secrets/pull/1?shareId=131a11e1-7041-41a5-a959-5b437b10fd7c).